### PR TITLE
Preserve error reason in query/transaction

### DIFF
--- a/Runtime/Chromia/PostchainClient/Unity/PostchainRequestRaw.cs
+++ b/Runtime/Chromia/PostchainClient/Unity/PostchainRequestRaw.cs
@@ -30,10 +30,8 @@ namespace Chromia.Postchain.Client.Unity
             request.downloadHandler = new DownloadHandlerBuffer();
             yield return request.SendWebRequest();
 
-            if (!CheckError(request))
-            {
-                this.content = request.downloadHandler.text;
-            }
+            CheckError(request);
+            this.content = request.downloadHandler?.text;
         }
 
         public virtual IEnumerator Post(string payload)
@@ -49,10 +47,8 @@ namespace Chromia.Postchain.Client.Unity
 
             yield return request.SendWebRequest();
 
-            if (!CheckError(request))
-            {
-                this.content = request.downloadHandler.text;
-            }
+            CheckError(request);
+            this.content = request.downloadHandler?.text;
         }
 
         private bool CheckError(UnityWebRequest request)


### PR DESCRIPTION
When a transaction is rejected, usually the rell node will return a reject reason e.g. "Not enough token in balance".

In this case
- `request.error`  will be `"Transaction rejected"`
- `request.downloadHandler.text` will be `"Not enough token in balance"` which is what the actual reject reason.

So in the case of error `request.downloadHandler.text` is still needed most of the time.

This is the temp fix we're doing in our project. Please consult proper way to update.